### PR TITLE
Fix `valid_cnpj?` spec

### DIFF
--- a/lib/brazilian_documents.ex
+++ b/lib/brazilian_documents.ex
@@ -57,7 +57,7 @@ defmodule BrazilianDocuments do
       false
 
   """
-  @spec valid_cpf?(value :: String.t()) :: boolean()
+  @spec valid_cnpj?(value :: String.t()) :: boolean()
   def valid_cnpj?(value) when is_binary(value) do
     if Regex.match?(~r/^(\d{14}|\d{2}\.\d{3}\.\d{3}\/\d{4}\-\d{2})$/, value) do
       numbers = to_numbers_list(value)


### PR DESCRIPTION
Hi, I believe the spec of `valid_cnpj?` was a duplication of the `valid_cpf?`. Just a small fix.