### PR TITLE
Add option to generate cnpj function to generate subsidiaries

### DIFF
--- a/lib/brazilian_documents.ex
+++ b/lib/brazilian_documents.ex
@@ -144,6 +144,7 @@ defmodule BrazilianDocuments do
       iex> BrazilianDocuments.valid_cpf?(cnpj)
       true
 
+
   """
   @spec generate_cpf :: String.t()
   def generate_cpf do
@@ -163,15 +164,49 @@ defmodule BrazilianDocuments do
       iex> BrazilianDocuments.valid_cnpj?(cnpj)
       true
 
+      iex> cnpj = BrazilianDocuments.generate_cnpj(subsidiary: 13)
+      iex> BrazilianDocuments.valid_cnpj?(cnpj)
+      true
+      iex> String.slice(cnpj, 8..11) 
+      "0013"
+
+      iex> cnpj = BrazilianDocuments.generate_cnpj(subsidiary: "13")
+      iex> BrazilianDocuments.valid_cnpj?(cnpj)
+      true
+      iex> String.slice(cnpj, 8..11) 
+      "0013"
+
   """
   @spec generate_cnpj :: String.t()
-  def generate_cnpj do
-    numbers = random_numbers(12)
+  def generate_cnpj(opts \\ []) do
+    inscription_number = random_numbers(8)
+
+    subsidiary =
+      opts
+      |> Keyword.get(:subsidiary)
+      |> format_subsidiary()
+
+    numbers = inscription_number ++ subsidiary
 
     {first_digit, second_digit} =
       checker_digits(numbers, 12, [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2])
 
     numbers |> Enum.concat([first_digit, second_digit]) |> Enum.join("")
+  end
+
+  defp format_subsidiary(nil), do: random_numbers(4)
+
+  defp format_subsidiary(subsidiary) when is_binary(subsidiary) do
+    subsidiary |> String.pad_leading(4, "0") |> to_numbers_list() |> Enum.take(4)
+  end
+
+  defp format_subsidiary(subsidiary) when is_integer(subsidiary) do
+    digits =
+      subsidiary
+      |> Integer.digits()
+      |> Enum.take(4)
+
+    for index <- -4..-1, do: Enum.at(digits, index, 0)
   end
 
   defp random_numbers(amount) do

--- a/lib/brazilian_documents.ex
+++ b/lib/brazilian_documents.ex
@@ -169,6 +169,12 @@ defmodule BrazilianDocuments do
       iex> String.slice(cnpj, 8..11) 
       "0013"
 
+      iex> cnpj = BrazilianDocuments.generate_cnpj(subsidiary: 12345)
+      iex> BrazilianDocuments.valid_cnpj?(cnpj)
+      true
+      iex> String.slice(cnpj, 8..11) 
+      "1234"
+
       iex> cnpj = BrazilianDocuments.generate_cnpj(subsidiary: "13")
       iex> BrazilianDocuments.valid_cnpj?(cnpj)
       true
@@ -176,7 +182,9 @@ defmodule BrazilianDocuments do
       "0013"
 
   """
-  @spec generate_cnpj :: String.t()
+  @type cnpj_opts :: [subsidiary: String.t() | integer()]
+  @spec generate_cnpj(opts :: cnpj_opts) :: String.t()
+  @spec generate_cnpj() :: String.t()
   def generate_cnpj(opts \\ []) do
     inscription_number = random_numbers(8)
 
@@ -195,17 +203,14 @@ defmodule BrazilianDocuments do
 
   defp format_subsidiary(nil), do: random_numbers(4)
 
-  defp format_subsidiary(subsidiary) when is_binary(subsidiary) do
-    subsidiary |> String.pad_leading(4, "0") |> to_numbers_list() |> Enum.take(4)
+  defp format_subsidiary(subsidiary) when is_integer(subsidiary) do
+    subsidiary
+    |> to_string()
+    |> format_subsidiary()
   end
 
-  defp format_subsidiary(subsidiary) when is_integer(subsidiary) do
-    digits =
-      subsidiary
-      |> Integer.digits()
-      |> Enum.take(4)
-
-    for index <- -4..-1, do: Enum.at(digits, index, 0)
+  defp format_subsidiary(subsidiary) when is_binary(subsidiary) do
+    subsidiary |> String.pad_leading(4, "0") |> to_numbers_list() |> Enum.take(4)
   end
 
   defp random_numbers(amount) do

--- a/lib/brazilian_documents.ex
+++ b/lib/brazilian_documents.ex
@@ -144,7 +144,6 @@ defmodule BrazilianDocuments do
       iex> BrazilianDocuments.valid_cpf?(cnpj)
       true
 
-
   """
   @spec generate_cpf :: String.t()
   def generate_cpf do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule BrazilianDocuments.MixProject do
   def project do
     [
       app: :brazilian_documents,
-      version: "0.3.1",
+      version: "0.4.0",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
## Motivation

We would like to generate a random CNPJ with a defined subsidiary.

## Proposed Solution

Add option in function signature to pass a subsidiary in string or integer format to generate a random CNPJ with a defined subsidiary.
