### PR TITLE
Handle BrazilianDocument cast for CPF and CNPJ

### DIFF
--- a/lib/brazilian_documents/types/brazilian_document.ex
+++ b/lib/brazilian_documents/types/brazilian_document.ex
@@ -5,6 +5,9 @@ if Code.ensure_loaded?(Ecto.Type) do
     """
     use Ecto.Type
 
+    alias BrazilianDocuments.Types.CNPJ
+    alias BrazilianDocuments.Types.CPF
+
     import BrazilianDocuments, only: [valid_cnpj?: 1, valid_cpf?: 1]
 
     defstruct [:number, :kind]
@@ -21,9 +24,9 @@ if Code.ensure_loaded?(Ecto.Type) do
       end
     end
 
-    def cast(%__MODULE__{number: value}) when is_binary(value) do
-      cast(value)
-    end
+    def cast(%__MODULE__{number: value}), do: cast(value)
+    def cast(%CPF{number: value}), do: cast(value)
+    def cast(%CNPJ{number: value}), do: cast(value)
 
     def cast(_invalid), do: :error
 

--- a/lib/brazilian_documents/types/brazilian_document.ex
+++ b/lib/brazilian_documents/types/brazilian_document.ex
@@ -33,6 +33,8 @@ if Code.ensure_loaded?(Ecto.Type) do
     def load(value), do: cast(value)
 
     def dump(%__MODULE__{number: number}), do: {:ok, number}
+    def dump(%CPF{number: number}), do: {:ok, number}
+    def dump(%CNPJ{number: number}), do: {:ok, number}
 
     def dump(value) when is_binary(value) do
       case cast(value) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule BrazilianDocuments.MixProject do
   def project do
     [
       app: :brazilian_documents,
-      version: "0.4.0",
+      version: "0.4.1",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/brazilian_documents/types/brazilian_document_test.exs
+++ b/test/brazilian_documents/types/brazilian_document_test.exs
@@ -2,6 +2,8 @@ defmodule BrazilianDocuments.Types.BrazilianDocumentTest do
   use ExUnit.Case, async: true
 
   alias BrazilianDocuments.Types.BrazilianDocument
+  alias BrazilianDocuments.Types.CNPJ
+  alias BrazilianDocuments.Types.CPF
 
   describe "cast/1" do
     test "cast a valid CNPJ as a BrazilianDocument" do
@@ -32,10 +34,18 @@ defmodule BrazilianDocuments.Types.BrazilianDocumentTest do
                {:ok, %BrazilianDocument{number: "98083335088", kind: :cpf}}
     end
 
-    test "cast a BrazilianDocument struct" do
-      cnpj = %BrazilianDocument{number: "90536710000123", kind: :cnpj}
+    test "cast a BrazilianDocument type structs" do
+      cnpj_brazilian_document = %BrazilianDocument{number: "90536710000123", kind: :cnpj}
+      cnpj = %CNPJ{number: "90536710000123"}
 
-      assert BrazilianDocument.cast(cnpj) == {:ok, cnpj}
+      cpf_brazilian_document = %BrazilianDocument{number: "47729076020", kind: :cpf}
+      cpf = %CPF{number: "47729076020"}
+
+      assert BrazilianDocument.cast(cnpj) == {:ok, cnpj_brazilian_document}
+      assert BrazilianDocument.cast(cnpj_brazilian_document) == {:ok, cnpj_brazilian_document}
+
+      assert BrazilianDocument.cast(cpf) == {:ok, cpf_brazilian_document}
+      assert BrazilianDocument.cast(cpf_brazilian_document) == {:ok, cpf_brazilian_document}
     end
 
     test "error for invalid brazilian document number" do

--- a/test/brazilian_documents/types/brazilian_document_test.exs
+++ b/test/brazilian_documents/types/brazilian_document_test.exs
@@ -35,17 +35,17 @@ defmodule BrazilianDocuments.Types.BrazilianDocumentTest do
     end
 
     test "cast a BrazilianDocument type structs" do
-      cnpj_brazilian_document = %BrazilianDocument{number: "90536710000123", kind: :cnpj}
+      brazilian_document_cnpj = %BrazilianDocument{number: "90536710000123", kind: :cnpj}
       cnpj = %CNPJ{number: "90536710000123"}
 
-      cpf_brazilian_document = %BrazilianDocument{number: "47729076020", kind: :cpf}
+      brazilian_document_cpf = %BrazilianDocument{number: "47729076020", kind: :cpf}
       cpf = %CPF{number: "47729076020"}
 
-      assert BrazilianDocument.cast(cnpj) == {:ok, cnpj_brazilian_document}
-      assert BrazilianDocument.cast(cnpj_brazilian_document) == {:ok, cnpj_brazilian_document}
+      assert BrazilianDocument.cast(cnpj) == {:ok, brazilian_document_cnpj}
+      assert BrazilianDocument.cast(brazilian_document_cnpj) == {:ok, brazilian_document_cnpj}
 
-      assert BrazilianDocument.cast(cpf) == {:ok, cpf_brazilian_document}
-      assert BrazilianDocument.cast(cpf_brazilian_document) == {:ok, cpf_brazilian_document}
+      assert BrazilianDocument.cast(cpf) == {:ok, brazilian_document_cpf}
+      assert BrazilianDocument.cast(brazilian_document_cpf) == {:ok, brazilian_document_cpf}
     end
 
     test "error for invalid brazilian document number" do
@@ -85,14 +85,18 @@ defmodule BrazilianDocuments.Types.BrazilianDocumentTest do
 
   describe "dump/1" do
     test "dumb a CNPJ BrazilianDocument struct" do
-      cnpj = %BrazilianDocument{number: "90536710000123", kind: :cnpj}
+      brazilian_document_cnpj = %BrazilianDocument{number: "90536710000123", kind: :cnpj}
+      brazilian_document_cpf = %BrazilianDocument{number: "98083335088", kind: :cpf}
+      cnpj = %CNPJ{number: "90536710000123"}
+      cpf = %CPF{number: "47729076020"}
+
+      assert BrazilianDocument.dump(brazilian_document_cnpj) ==
+               {:ok, brazilian_document_cnpj.number}
+
+      assert BrazilianDocument.dump(brazilian_document_cpf) ==
+               {:ok, brazilian_document_cpf.number}
 
       assert BrazilianDocument.dump(cnpj) == {:ok, cnpj.number}
-    end
-
-    test "dumb a CPF BrazilianDocument struct" do
-      cpf = %BrazilianDocument{number: "98083335088", kind: :cpf}
-
       assert BrazilianDocument.dump(cpf) == {:ok, cpf.number}
     end
 


### PR DESCRIPTION
### Motivation
`BrazilianDocuments.Types.BrazilianDocument` handle cast for `BrazilianDocuments.Types.CPF` and `BrazilianDocuments.Types.CNPJ`